### PR TITLE
Basic Min Score Threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ User::whereFuzzy('name', 'jd')
     ->orderBy('relevance_email', 'desc')
     ->first();
 ```
+### Setting Minimum Match Threshold
+
+When using quest an overall score will be assigned to each row `_fuzzy_relevance_` with a range of 0-100.
+
+You can enforce a minimum match standard and limit results returned by using `->atLeastFuzzy()`
+
+```php
+User::whereFuzzy('name', 'jd')
+    ->atLeastFuzzy(70)
+    ->first();
+
+// Equivalent to:
+
+User::whereFuzzy('name', 'jd')
+    ->having('_fuzzy_relevance_', '>',  70)
+    ->first();
+```
 
 ## Limitations
 

--- a/src/Macros/AtLeast.php
+++ b/src/Macros/AtLeast.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Quest\Macros;
+
+use Illuminate\Database\Query\Builder;
+
+class AtLeast
+{
+    /**
+     * Construct a fuzzy search expression.
+     *
+     **/
+    public static function make(Builder $builder, int $minScore) : Builder
+    {
+        $builder->having('_fuzzy_relevance_', '>',  $minScore);
+        return $builder;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Quest;
 
 use Closure;
+use Quest\Macros\AtLeast;
 use Quest\Macros\WhereFuzzy;
 use Quest\Macros\OrderByFuzzy;
 use Illuminate\Database\Query\Builder;
@@ -40,5 +41,7 @@ class ServiceProvider extends Provider
 
             return WhereFuzzy::makeOr($this, $field, $value);
         });
+
+        Builder::macro('atLeastFuzzy', fn($minScore) => AtLeast::make($this, $minScore));
     }
 }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -179,13 +179,13 @@ class PackageTest extends TestCase
     public function it_can_limit_minimum_score()
     {
         $results = User::whereFuzzy('name', 'joh Do')
-            ->atLeastFuzzy(70)
+            ->atLeastFuzzy(65)
             ->get();
 
         $this->assertEquals('John Doe', $results->first()->name);
 
         $results = User::whereFuzzy('name', 'joh Do')
-            ->atLeastFuzzy(95)
+            ->atLeastFuzzy(70)
             ->get();
 
         $this->assertCount(0, $results);

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -174,4 +174,20 @@ class PackageTest extends TestCase
 
         $this->assertEquals('Jane Doe', $results->first()->name);
     }
+
+    /** @test */
+    public function it_can_limit_minimum_score()
+    {
+        $results = User::whereFuzzy('name', 'john Do')
+            ->atLeastFuzzy(70)
+            ->get();
+
+        $this->assertEquals('John Doe', $results->first()->name);
+
+        $results = User::whereFuzzy('name', 'john Do')
+            ->atLeastFuzzy(95)
+            ->get();
+
+        $this->assertCount(0, $results);
+    }
 }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -178,13 +178,13 @@ class PackageTest extends TestCase
     /** @test */
     public function it_can_limit_minimum_score()
     {
-        $results = User::whereFuzzy('name', 'john Do')
+        $results = User::whereFuzzy('name', 'joh Do')
             ->atLeastFuzzy(70)
             ->get();
 
         $this->assertEquals('John Doe', $results->first()->name);
 
-        $results = User::whereFuzzy('name', 'john Do')
+        $results = User::whereFuzzy('name', 'joh Do')
             ->atLeastFuzzy(95)
             ->get();
 


### PR DESCRIPTION
This introduces a minimum score threshold.

Please note, I could easily get a test environment set up so I guessed at the threshold for the test assertions.


From the updated Reame:

### Setting Minimum Match Threshold

When using quest an overall score will be assigned to each row `_fuzzy_relevance_` with a range of 0-100.

You can enforce a minimum match standard and limit results returned by using `->atLeastFuzzy()`

```php
User::whereFuzzy('name', 'jd')
    ->atLeastFuzzy(70)
    ->first();

// Equivalent to:

User::whereFuzzy('name', 'jd')
    ->having('_fuzzy_relevance_', '>',  70)
    ->first();
```
